### PR TITLE
corrected a typo in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ Would be nice to add in the future:
 - SPI
 - etc...
 
-It works by memory-mapping the bcm2835 gpio range, and therefor require root/administrative-rights to run.
+It works by memory-mapping the bcm2835 gpio range, and therefore require root/administrative-rights to run.


### PR DESCRIPTION
Hey man, you were missing an e in the Readme.md file.  P.S. thanks for making this library, totally made my IR remote installation for my RPi easier.
