### PR TITLE
Unmap both arrays

### DIFF
--- a/rpio.go
+++ b/rpio.go
@@ -304,5 +304,6 @@ func Open() (err error) {
 func Close() {
 	memlock.Lock()
 	syscall.Munmap(mem8)
+	syscall.Munmap(mem)
 	memlock.Unlock()
 }


### PR DESCRIPTION
If you try to reopen Rpio after closing it, the library will crash since `mem` will still be wired to the old address
