### PR TITLE
Support the new IO port range for raspberry pi 2.

### DIFF
--- a/rpio.go
+++ b/rpio.go
@@ -309,8 +309,8 @@ func Close() error {
 	return syscall.Munmap(mem8)
 }
 
-// Read /proc/cpuinfo and detect whether we're running on an RPI1 or RPI2.
-// Returns 1 or 2 depending on platform.
+// Read /proc/device-tree/soc/ranges and determine the base address.
+// Use the default Raspberry Pi 1 base address if this fails.
 func getGPIOBase() (base int64) {
 	base = pi1GPIOBase
 	ranges, err := os.Open("/proc/device-tree/soc/ranges")

--- a/rpio.go
+++ b/rpio.go
@@ -58,7 +58,6 @@ package rpio
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"os"
 	"reflect"
 	"sync"
@@ -329,6 +328,5 @@ func getGPIOBase() (base int64) {
 	if err != nil {
 		return
 	}
-	fmt.Printf("%X", out)
 	return int64(out + 0x200000)
 }

--- a/rpio.go
+++ b/rpio.go
@@ -58,6 +58,7 @@ package rpio
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"reflect"
 	"sync"
@@ -323,10 +324,11 @@ func getGPIOBase() (base int64) {
 		return
 	}
 	buf := bytes.NewReader(b)
-	var out int64
-	err = binary.Read(buf, binary.LittleEndian, &out)
+	var out uint32
+	err = binary.Read(buf, binary.BigEndian, &out)
 	if err != nil {
 		return
 	}
-	return out + 0x200000
+	fmt.Printf("%X", out)
+	return int64(out + 0x200000)
 }


### PR DESCRIPTION
It seems pretty badly documented since the announcement says "Complete compatibility with Raspberry Pi 1", but the IO port ranges for the GPIO pins are different on the new Pi 2.

I can confirm that this code now works properly on my shiny new Raspberry Pi 2 and it did not before.

This should still work on old raspberry pi kernels that do not have device tree, as it falls back to the old default base address.