### PR TITLE
Implement clock and pwm modes

### DIFF
--- a/rpio.go
+++ b/rpio.go
@@ -81,13 +81,12 @@ const (
 )
 
 var (
-	base     int64
 	gpioBase int64
 	clkBase  int64
 )
 
 func init() {
-	base = getBase()
+	base := getBase()
 	gpioBase = base + gpioOffset
 	clkBase = base + clkOffset
 }
@@ -383,10 +382,10 @@ func Open() (err error) {
 	return nil
 }
 
-func memMap(fd uintptr, offset int64) (mem []uint32, mem8 []byte, err error) {
+func memMap(fd uintptr, base int64) (mem []uint32, mem8 []byte, err error) {
 	mem8, err = syscall.Mmap(
 		int(fd),
-		base+clkOffset,
+		base,
 		memLength,
 		syscall.PROT_READ|syscall.PROT_WRITE,
 		syscall.MAP_SHARED,

--- a/rpio.go
+++ b/rpio.go
@@ -315,18 +315,18 @@ func SetFreq(pin Pin, freq int) {
 	divi &= maxUint12
 	divf &= maxUint12
 
-	clkCtlReg := 0x70
-	clkDivReg := 0x74
+	clkCtlReg := 28
+	clkDivReg := 29
 	switch pin {
 	case 4, 20, 32, 34: // clk0
 		clkCtlReg += 0
 		clkDivReg += 0
 	case 5, 21, 42, 44: // clk1
-		clkCtlReg += 8
-		clkDivReg += 8
+		clkCtlReg += 2
+		clkDivReg += 2
 	case 6, 43: // clk2
-		clkCtlReg += 16
-		clkDivReg += 16
+		clkCtlReg += 4
+		clkDivReg += 4
 	default:
 		return
 	}

--- a/rpio.go
+++ b/rpio.go
@@ -311,7 +311,7 @@ func SetFreq(pin Pin, freq int) {
 	const maxUint12 = 4095
 
 	divi := uint32(sourceFreq / freq)
-	divf := uint32(((sourceFreq % freq) << 12) / sourceFreq)
+	divf := uint32(((sourceFreq % freq) << 12) / freq)
 
 	divi &= maxUint12
 	divf &= maxUint12

--- a/rpio.go
+++ b/rpio.go
@@ -191,7 +191,8 @@ func (pin Pin) PullOff() {
 }
 
 // PinMode sets the mode (direction) of a given pin (Input, Output or Clock)
-// Clock is possible only for some pins (bcm 4, 5, 6)
+//
+// Clock is possible only for some pins (bcm 4, 5, 6, 20, 21)
 func PinMode(pin Pin, mode Mode) {
 
 	// Pin fsel register, 0 or 1 depending on bank
@@ -310,7 +311,7 @@ func SetFreq(pin Pin, freq int) {
 	const maxUint12 = 4095
 
 	divi := uint32(source / freq)
-	divf := uint32(((source % freq) << 12) / source)
+	divf := uint32(((source % freq) << 12) / freq)
 
 	divi &= maxUint12
 	divf &= maxUint12

--- a/rpio.go
+++ b/rpio.go
@@ -345,7 +345,7 @@ func SetFreq(pin Pin, freq int) {
 	const enab = 1 << 4
 	const src = 1 << 0 // oscilator
 
-	clkMem[clkCtlReg] = PASSWORD | src // stop gpio clock
+	clkMem[clkCtlReg] = PASSWORD | (clkMem[clkCtlReg] &^ enab) // stop gpio clock (without changing src or mash)
 	for clkMem[clkCtlReg]&busy != 0 {
 		time.Sleep(time.Microsecond * 10)
 	} // ... and wait for not busy

--- a/rpio.go
+++ b/rpio.go
@@ -131,10 +131,9 @@ func (pin Pin) Output() {
 	PinMode(pin, Output)
 }
 
-// Set pin as Clock with given freq
-func (pin Pin) Clock(freq int) {
+// Set pin as Clock
+func (pin Pin) Clock() {
 	PinMode(pin, Clock)
-	SetClock(pin, freq)
 }
 
 // Set pin High
@@ -150,6 +149,10 @@ func (pin Pin) Low() {
 // Toggle pin state
 func (pin Pin) Toggle() {
 	TogglePin(pin)
+}
+
+func (pin Pin) Freq(freq int) {
+	SetFreq(pin, freq)
 }
 
 // Set pin Mode
@@ -302,7 +305,7 @@ func PullMode(pin Pin, pull Pull) {
 // Note that some pins share the same clock source, it means that
 // changing frequency for one pin will change it also for all pins within a group
 // The groups are: clk0 (4, 20, 32, 34), clk1 (5, 21, 42, 43) and clk2 (6 and 43)
-func SetClock(pin Pin, freq int) {
+func SetFreq(pin Pin, freq int) {
 	const source = 19200000 // oscilator frequency
 	const maxUint12 = 4095
 
@@ -350,7 +353,7 @@ func SetClock(pin Pin, freq int) {
 func Open() (err error) {
 	var file *os.File
 
-	// Open fd for rw mem access; try mem gpio first
+	// Open fd for rw mem access; try gpiomem first
 	file, err = os.OpenFile("/dev/gpiomem", os.O_RDWR|os.O_SYNC, 0)
 	if os.IsNotExist(err) { // try mem (need root)
 		file, err = os.OpenFile("/dev/mem", os.O_RDWR|os.O_SYNC, 0)


### PR DESCRIPTION
Hi there.
I managed to add third pin mode - clock.

It is just clock (using `CM_GPnDIV` and `CM_GPnCTL` registers) - no pwm (yet).

Suggestions about better method/function naming are welcomed.
I tried to be consistent with current ideology, but not sure if it makes sense.

So this:   `PinMode(pin, rpio.Clock)` <=> `pin.Mode(rpio.Clock)` <=> `pin.Clock()` 
is analogical to:   `PinMode(pin, rpio.Output)` <=> `pin.Mode(rpio.Output)` <=> `pin.Output()`

and this:   `SetFreq(pin, 10000)` <=> `pin.Freq(10000)` <=> `???`
is analogical to:   `WritePin(pin, rpio.High)` <=> `pin.Write(rpio.High)` <=> `pin.High()`


Also not sure if it might make sense to add more public methods eg. for stopping/resetting clocks.

Please merge this if you like it.
