### PR TITLE
Feature/SPI

### DIFF
--- a/rpio.go
+++ b/rpio.go
@@ -8,9 +8,13 @@ Supports simple operations such as:
 	- Pin read (high/low)
 	- Pin edge detection (no/rise/fall/any)
 	- Pull up/down/off
-And clock/pwm related oparations:
+Also clock/pwm related oparations:
 	- Set Clock frequency
 	- Set Duty cycle
+And SPI oparations:
+	- SPI transmit/recieve/exchange bytes
+	- Chip select
+	- Set speed
 
 Example of use:
 
@@ -238,10 +242,12 @@ func (pin Pin) EdgeDetected() bool {
 	return EdgeDetected(pin)
 }
 
-// PinMode sets the mode (direction) of a given pin (Input, Output, Clock or Pwm)
+// PinMode sets the mode of a given pin (Input, Output, Clock, Pwm or Spi)
 //
 // Clock is possible only for pins 4, 5, 6, 20, 21.
 // Pwm is possible only for pins 12, 13, 18, 19.
+//
+// Spi mode should not be set by this directly, use SpiBegin instead.
 func PinMode(pin Pin, mode Mode) {
 
 	// Pin fsel register, 0 or 1 depending on bank
@@ -296,7 +302,7 @@ func PinMode(pin Pin, mode Mode) {
 	memlock.Lock()
 	defer memlock.Unlock()
 
-	const pinMask = 7 // 0b111 - pinmode is 3 bits
+	const pinMask = 7 // 111 - pinmode is 3 bits
 
 	gpioMem[fselReg] = (gpioMem[fselReg] &^ (pinMask << shift)) | (f << shift)
 }

--- a/spi.go
+++ b/spi.go
@@ -1,15 +1,12 @@
+// SPI functionality is implemented here
 package rpio
 
 import (
 	"errors"
 )
 
-var (
-	SpiMapError = errors.New("SPI registers not mapped correctly - are you root?")
-)
-
 const (
-	SPI0 = iota // only spi0 supported for now
+	SPI0 = iota // only SPI0 supported for now
 	SPI1        // aux
 	SPI2        // aux
 )
@@ -20,9 +17,13 @@ const (
 	clkDivReg = 2
 )
 
-// Sets SPI pins of given device to SIP mode
-// (CE0, CE1, [CE2], SCLK, MOSI, MISO)
-// also reset SPI control register
+var (
+	SpiMapError = errors.New("SPI registers not mapped correctly - are you root?")
+)
+
+// Sets SPI pins of given device to SPI mode
+// (CE0, CE1, [CE2], SCLK, MOSI, MISO).
+// It also resets SPI control register.
 func SpiBegin(dev int) error {
 	spiMem[csReg] = 0 // reset spi settings to default
 	if spiMem[csReg] == 0 {
@@ -39,7 +40,7 @@ func SpiBegin(dev int) error {
 	return nil
 }
 
-// Sets SPI pins of given device to default (Input) mode
+// Sets SPI pins of given device to default (Input) mode.
 func SpiEnd(dev int) {
 	var pins = getSpiPins(dev)
 	for _, pin := range pins {
@@ -47,7 +48,7 @@ func SpiEnd(dev int) {
 	}
 }
 
-// Set (maximal) speed [Hz] of SPI clock
+// Set (maximal) speed [Hz] of SPI clock.
 // Param speed may be as big as 125MHz in theory, but
 // only values up to 31.25MHz are considered relayable.
 func SpiSpeed(speed int) {
@@ -57,8 +58,8 @@ func SpiSpeed(speed int) {
 }
 
 // Select chip, one of 0, 1, 2
-// for selecting slave on CE0, CE1, or CE2
-func SpiChipSelect(chip int) { // control & status
+// for selecting slave on CE0, CE1, or CE2 pin
+func SpiChipSelect(chip int) {
 	const csMask = 3 // chip select has 2 bits
 
 	cs := uint32(chip & csMask)
@@ -66,32 +67,50 @@ func SpiChipSelect(chip int) { // control & status
 	spiMem[csReg] = spiMem[csReg]&^csMask | cs
 }
 
+// SpiTransmit takes one or more bytes and send them to slave.
+//
+// Data received from slave are ignored.
+// Use spread operator to send slice of bytes.
+func SpiTransmit(data ...byte) {
+	SpiExchange(append(data[:0:0], data...)) // clone data because it will be rewriten by received bytes
+}
+
+// SpiReceive receives n bytes from slave.
+//
+// Note that n zeroed bytes are send to slave as side effect.
+func SpiReceive(n int) []byte {
+	data := make([]byte, n, n)
+	SpiExchange(data)
+	return data
+}
+
 // Transmit all bytes in data to slave
-// and simultaneously receives bytes from slave to data
-func SpiTransfer(data []byte) { // control & status
+// and simultaneously receives bytes from slave to data.
+//
+// If you want to only send or only receive, use SpiTransmit/SpiReceive
+func SpiExchange(data []byte) {
 	const ta = 1 << 7   // transfer active
 	const txd = 1 << 18 // tx fifo can accept data
 	const rxd = 1 << 17 // rx fifo contains data
 	const done = 1 << 16
-
-	length := len(data)
-	i := 0 // data index
 
 	clearSpiTxRxFifo()
 
 	// set TA = 1
 	spiMem[csReg] |= ta
 
-	for i < length {
-		// Poll TXD writing bytes to SPI_FIFO
+	for i := range data {
+		// wait for TXD
 		for spiMem[csReg]&txd == 0 {
 		}
+		// write bytes to SPI_FIFO
 		spiMem[fifoReg] = uint32(data[i])
-		// Poll RXD reading bytes from SPI_FIFO
+
+		// wait for RXD
 		for spiMem[csReg]&rxd == 0 {
 		}
+		// read bytes from SPI_FIFO
 		data[i] = byte(spiMem[fifoReg])
-		i++
 	}
 
 	// wait for DONE
@@ -102,32 +121,27 @@ func SpiTransfer(data []byte) { // control & status
 	spiMem[csReg] &^= ta
 }
 
-func setSpiDiv(div uint32) {
-	const divMask = 1<<16 - 1 - 1 // cdiv have 16 bits and must be odd (for some reason)
+// set spi clock divider value
+func setSpiDiv(cdiv uint32) {
+	const cdivMask = 1<<16 - 1 - 1 // cdiv have 16 bits and must be odd (for some reason)
 	spiMem[clkDivReg] = div & divMask
 }
 
+// clear both FIFOs
 func clearSpiTxRxFifo() {
 	const clearTxRx = 1<<5 | 1<<4
-
 	spiMem[csReg] |= clearTxRx
 }
 
 func getSpiPins(dev int) []Pin {
 	switch dev {
 	case SPI0:
-		return []Pin{
-			7, 8, 9, 10, 11,
-			// 35, 36, 37, 38, 39, // only one set of SPI0 can be set in Spi mode at a time
-		}
+		return []Pin{7, 8, 9, 10, 11}
+		// ommit 35, 36, 37, 38, 39 - only one set of SPI0 can be set in Spi mode at a time
 	case SPI1:
-		return []Pin{
-			16, 17, 18, 19, 20, 21,
-		}
+		return []Pin{16, 17, 18, 19, 20, 21}
 	case SPI2:
-		return []Pin{
-			40, 41, 42, 43, 44, 45,
-		}
+		return []Pin{40, 41, 42, 43, 44, 45}
 	default:
 		return []Pin{}
 	}

--- a/spi.go
+++ b/spi.go
@@ -1,0 +1,134 @@
+package rpio
+
+import (
+	"errors"
+)
+
+var (
+	SpiMapError = errors.New("SPI registers not mapped correctly - are you root?")
+)
+
+const (
+	SPI0 = iota // only spi0 supported for now
+	SPI1        // aux
+	SPI2        // aux
+)
+
+const (
+	csReg     = 0
+	fifoReg   = 1 // TX/RX FIFO
+	clkDivReg = 2
+)
+
+// Sets SPI pins of given device to SIP mode
+// (CE0, CE1, [CE2], SCLK, MOSI, MISO)
+// also reset SPI control register
+func SpiBegin(dev int) error {
+	spiMem[csReg] = 0 // reset spi settings to default
+	if spiMem[csReg] == 0 {
+		// this should not read only zeroes after reset -> mem map failed
+		return SpiMapError
+	}
+
+	for _, pin := range getSpiPins(dev) {
+		pin.Mode(Spi)
+	}
+
+	clearSpiTxRxFifo()
+	setSpiDiv(128)
+	return nil
+}
+
+// Sets SPI pins of given device to default (Input) mode
+func SpiEnd(dev int) {
+	var pins = getSpiPins(dev)
+	for _, pin := range pins {
+		pin.Mode(Input)
+	}
+}
+
+// Set (maximal) speed [Hz] of SPI clock
+// Param speed may be as big as 125MHz in theory, but
+// only values up to 31.25MHz are considered relayable.
+func SpiSpeed(speed int) {
+	const baseFreq = 250 * 1000000
+	cdiv := uint32(baseFreq / speed)
+	setSpiDiv(cdiv)
+}
+
+// Select chip, one of 0, 1, 2
+// for selecting slave on CE0, CE1, or CE2
+func SpiChipSelect(chip int) { // control & status
+	const csMask = 3 // chip select has 2 bits
+
+	cs := uint32(chip & csMask)
+
+	spiMem[csReg] = spiMem[csReg]&^csMask | cs
+}
+
+// Transmit all bytes in data to slave
+// and simultaneously receives bytes from slave to data
+func SpiTransfer(data []byte) { // control & status
+	const ta = 1 << 7   // transfer active
+	const txd = 1 << 18 // tx fifo can accept data
+	const rxd = 1 << 17 // rx fifo contains data
+	const done = 1 << 16
+
+	length := len(data)
+	i := 0 // data index
+
+	clearSpiTxRxFifo()
+
+	// set TA = 1
+	spiMem[csReg] |= ta
+
+	for i < length {
+		// Poll TXD writing bytes to SPI_FIFO
+		for spiMem[csReg]&txd == 0 {
+		}
+		spiMem[fifoReg] = uint32(data[i])
+		// Poll RXD reading bytes from SPI_FIFO
+		for spiMem[csReg]&rxd == 0 {
+		}
+		data[i] = byte(spiMem[fifoReg])
+		i++
+	}
+
+	// wait for DONE
+	for spiMem[csReg]&done == 0 {
+	}
+
+	// Set TA = 0
+	spiMem[csReg] &^= ta
+}
+
+func setSpiDiv(div uint32) {
+	const divMask = 1<<16 - 1 - 1 // cdiv have 16 bits and must be odd (for some reason)
+	spiMem[clkDivReg] = div & divMask
+}
+
+func clearSpiTxRxFifo() {
+	const clearTxRx = 1<<5 | 1<<4
+
+	spiMem[csReg] |= clearTxRx
+}
+
+func getSpiPins(dev int) []Pin {
+	switch dev {
+	case SPI0:
+		return []Pin{
+			7, 8, 9, 10, 11,
+			// 35, 36, 37, 38, 39, // only one set of SPI0 can be set in Spi mode at a time
+		}
+	case SPI1:
+		return []Pin{
+			16, 17, 18, 19, 20, 21,
+		}
+	case SPI2:
+		return []Pin{
+			40, 41, 42, 43, 44, 45,
+		}
+	default:
+		return []Pin{}
+	}
+}

--- a/spi_test.go
+++ b/spi_test.go
@@ -2,15 +2,22 @@ package rpio
 
 import ()
 
-func Example_SPI() {
-	SpiBegin(SPI0) // BCM pins 7 to 11
+func ExampleSpiTransmit() {
+	SpiTransmit(0xFF)             // send single byte
+	SpiTransmit(0xDE, 0xAD, 0xBE) // send several bytes
 
-	SpiSpeed(144000) // 144kHz
-	SpiChipSelect(1) // CE1
+	data := []byte{'H', 'e', 'l', 'l', 'o', 0}
+	SpiTransmit(data...) // send slice of bytes
+}
 
-	SpiTransmit(0xFF)
-	SpiTransmit(0xDE, 0xAD)
-	SpiTransmit(data...)
+func ExampleSpiBegin() {
+	err := SpiBegin(Spi0) // pins 7 to 11
+	if err != nil {
+		panic(err)
+	}
 
-	SpiEnd(SPI0)
+	// any Spi functions must go there...
+	SpiTransmit(42)
+
+	SpiEnd(Spi0)
 }

--- a/spi_test.go
+++ b/spi_test.go
@@ -1,0 +1,16 @@
+package rpio
+
+import ()
+
+func Example_SPI() {
+	SpiBegin(SPI0) // BCM pins 7 to 11
+
+	SpiSpeed(144000) // 144kHz
+	SpiChipSelect(1) // CE1
+
+	SpiTransmit(0xFF)
+	SpiTransmit(0xDE, 0xAD)
+	SpiTransmit(data...)
+
+	SpiEnd(SPI0)
+}


### PR DESCRIPTION
Hi, I implemented basic SPI functionality.

(I originally wanted to first start a discussion about API and implementation details first, but after writing long, long text in new issue form I accidentally hit back button and lost the text :man_facepalming:. So I decided to just implement it. But we can still run discussion here.)

### Summary of what I have done:
(i will be referencing [BCM2835-ARM-Peripherals.pdf](https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf))

- Rpi has 3 SPI devices, (*SPI0*, *SPI1*, *SPI2*). I decided to support just *SPI0* for now, the other two are part of Aux and has different API and functionality.
- I implemented only standard *4-wire* mode of SPI (=separated MOSI & MISO wires), rpi also support *3-wire* (=single bidirectional MIMO wire) and *LoSSI*, but these are not so common I guess. [see 10.2]
- I implemented data transfer using *Polling* approach, other possibilities are using interruptions and DMA, polling is the easiest. [see 10.6]
- I implemented it in a separated file as part of the package - all related functions are prefixed with `Spi`. I was thinking about implementing it as it's own nested package `spi`, but it would be probably more complicated

### API
#### setup/teardown
  - `rpio.SpiBegin(rpio.Spi0)` has to be called first before using any Spi func. It will change pin modes to `Spi` and initialize default setting.
  - `rpio.SpiEnd(rpio.Spi0)` should be called at the end, it will switch pin modes to `Input`.
#### transferring data
  - `rpio.SpiTransmit(byte)` or `rpio.SpiTransmit(bytes...)` will transmit byte or bytes to slave.
  - `rpio.SpiRecieve(n)` will return n bytes received from slave.
  - `rpio.SpiExchange(buffer)` will simultaneously transmit data from the buffer to slave and data from slave to the same buffer in full duplex way.
#### settings
  - `rpio.SpiSpeed(hz)` will set transmit speed of SPI
  - `rpio.SpiChipSelect(n)` will select chip/slave (ce0, ce1, or ce2) to which transferring will be done
  - `rpio.SpiChipSelectPolarity(n, pol)` set chip select polarity (low enabled is used by default which usually works most of the time)
  - `rpio.SpiMode(cpol, cpha)` set clock/communication mode (=combination of clock polarity and clock phase; cpol=0, cpha=0 is used by default which usually works most of the time)
    

### issues
I only have resources now to test MOSI transfer, but not MISO - only have a ouptup-only device.
So if somebody with some "readable" slave SPI chip could test the recieving functionality, that would be great.
