### PR TITLE
Updated to support Raspberry Pi 4 GPIO Base Address

### DIFF
--- a/examples/pullup/pullup.go
+++ b/examples/pullup/pullup.go
@@ -23,10 +23,10 @@ func main() {
 
 	// Pull up and read value
 	pin.PullUp()
-	fmt.Printf("PullUp: %d\n", pin.Read())
+	fmt.Printf("PullUp: %d, %d\n", pin.Read(), pin.ReadPull())
 
 	// Pull down and read value
 	pin.PullDown()
-	fmt.Printf("PullDown: %d\n", pin.Read())
+	fmt.Printf("PullDown: %d, %d\n", pin.Read(), pin.ReadPull())
 
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/stianeikeland/go-rpio/v4
+
+go 1.13

--- a/rpio.go
+++ b/rpio.go
@@ -98,7 +98,7 @@ const (
 	memLength = 4096
 )
 
-// BCM 2711 has a differnet mechanism for pin pull-up/pull-down/enable
+// BCM 2711 has a different mechanism for pull-up/pull-down/enable
 const (
 	GPPUPPDN0 = 57        // Pin pull-up/down for pins 15:0 
 	GPPUPPDN1 = 58        // Pin pull-up/down for pins 31:16 
@@ -145,6 +145,7 @@ const (
 	PullOff Pull = iota
 	PullDown
 	PullUp
+	PullNone
 )
 
 // Edge events
@@ -252,7 +253,7 @@ func (pin Pin) PullOff() {
 
 func (pin Pin) ReadPull() Pull {
 	if !isBCM2711() {
-		return PullOff	// TODO: Can you read pull state on other Pi boards?
+		return PullNone	// Can't read pull-up/pull-down state on other Pi boards
 	}
 
 	reg := GPPUPPDN0 + (uint8(pin) >> 4)
@@ -265,7 +266,7 @@ func (pin Pin) ReadPull() Pull {
 	case 2:
 		return PullDown
 	default:
-		return PullOff
+		return PullNone	// Invalid
 	}
 }
 

--- a/rpio.go
+++ b/rpio.go
@@ -63,6 +63,8 @@ See the spec for full details of the BCM2835 controller:
 https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf
 and https://elinux.org/BCM2835_datasheet_errata - for errors in that spec
 
+Changes to support the BCM2711, used on the Raspberry Pi 4, were cribbed from https://github.com/RPi-Distro/raspi-gpio/
+
 */
 package rpio
 
@@ -94,6 +96,14 @@ const (
 	intrOffset  = 0x00B000
 
 	memLength = 4096
+)
+
+// BCM 2711 has a differnet mechanism for pin pull-up/pull-down/enable
+const (
+	GPPUPPDN0 = 57        // Pin pull-up/down for pins 15:0 
+	GPPUPPDN1 = 58        // Pin pull-up/down for pins 31:16 
+	GPPUPPDN2 = 59        // Pin pull-up/down for pins 47:32 
+	GPPUPPDN3 = 60        // Pin pull-up/down for pins 57:48
 )
 
 var (
@@ -238,6 +248,25 @@ func (pin Pin) PullDown() {
 // PullOff: Disable pullup/down on pin
 func (pin Pin) PullOff() {
 	PullMode(pin, PullOff)
+}
+
+func (pin Pin) ReadPull() Pull {
+	if !isBCM2711() {
+		return PullOff	// TODO: Can you read pull state on other Pi boards?
+	}
+
+	reg := GPPUPPDN0 + (uint8(pin) >> 4)
+	bits := gpioMem[reg] >> ((uint8(pin) & 0xf) << 1) & 0x3
+	switch bits {
+	case 0:
+		return PullOff
+	case 1:
+		return PullUp
+	case 2:
+		return PullDown
+	default:
+		return PullOff
+	}
 }
 
 // Detect: Enable edge event detection on pin
@@ -430,32 +459,54 @@ func EdgeDetected(pin Pin) bool {
 }
 
 func PullMode(pin Pin, pull Pull) {
-	// Pull up/down/off register has offset 38 / 39, pull is 37
-	pullClkReg := pin/32 + 38
-	pullReg := 37
-	shift := pin % 32
-
+		
 	memlock.Lock()
 	defer memlock.Unlock()
 
-	switch pull {
-	case PullDown, PullUp:
-		gpioMem[pullReg] |= uint32(pull)
-	case PullOff:
+	if isBCM2711() {
+		pullreg := GPPUPPDN0 + (pin >> 4)
+		pullshift := (pin & 0xf) << 1
+		
+		var p uint32 
+		
+		switch pull {
+		case PullOff:
+			p = 0
+		case PullUp:
+			p = 1
+		case PullDown:
+			p = 2;
+		}
+		
+		// This is verbatim C code from raspi-gpio.c
+		pullbits := gpioMem[pullreg]
+		pullbits &= ^(3 << pullshift)
+		pullbits |= (p << pullshift)
+		gpioMem[pullreg]= pullbits
+	} else {
+		// Pull up/down/off register has offset 38 / 39, pull is 37
+		pullClkReg := pin/32 + 38
+		pullReg := 37
+		shift := pin % 32
+		
+		switch pull {
+		case PullDown, PullUp:
+			gpioMem[pullReg] |= uint32(pull)
+		case PullOff:
+			gpioMem[pullReg] &^= 3
+		}
+		
+		// Wait for value to clock in, this is ugly, sorry :(
+		time.Sleep(time.Microsecond)
+		
+		gpioMem[pullClkReg] = 1 << shift
+		
+		// Wait for value to clock in
+		time.Sleep(time.Microsecond)
+		
 		gpioMem[pullReg] &^= 3
+		gpioMem[pullClkReg] = 0
 	}
-
-	// Wait for value to clock in, this is ugly, sorry :(
-	time.Sleep(time.Microsecond)
-
-	gpioMem[pullClkReg] = 1 << shift
-
-	// Wait for value to clock in
-	time.Sleep(time.Microsecond)
-
-	gpioMem[pullReg] &^= 3
-	gpioMem[pullClkReg] = 0
-
 }
 
 // SetFreq: Set clock speed for given pin in Clock or Pwm mode
@@ -754,4 +805,10 @@ func getBase() int64 {
 
 	// Default to Pi 1
 	return int64(bcm2835Base)
+}
+
+// The Pi 4 uses a BCM 2711, which has different register offsets and base addresses than the rest of the Pi family (so far).  This
+// helper function checks if we're on a 2711 and hence a Pi 4
+func isBCM2711() bool {
+	return gpioMem[GPPUPPDN3] != 0x6770696f
 }


### PR DESCRIPTION
As requested, a pull request for my changes to support Pi4. Note that this is a bit different than the patch I attached to be bug in that it encapsulates error checking in the readBase() helper function.