### PR TITLE
Support PullMode on BCM2711

### DIFF
--- a/rpio.go
+++ b/rpio.go
@@ -430,7 +430,7 @@ func EdgeDetected(pin Pin) bool {
 
 func PullMode(pin Pin, pull Pull) {
 	// BCM2711  - offset 60 has model of BCM, BCM2711 = 0x6770696f
-	if(gpioMem[60] == 0x6770696f) {
+	if(gpioMem[62] == 0x6770696f) {
 		// 2711 reverses up/down sense
 		// Based on code from https://github.com/warthog618/gpio
 		switch pull {


### PR DESCRIPTION
The new Raspberry 4 uses BCM2711, the method for defining the Pull mode changed, and on this new version and no Pull modes were not working on the pi 4.
I imported code inspired in the RPIO python module & warthog618/gpio that identifies the current BCM model and sets the pull mode accordingly.
I know this was made around BCM2835, and my code has a few magic numbers, but this small piece of code may be useful for people trying to use this on the 4 - and hopefully can get rewritten to the maintainers coding style.
Thank you for maintaining this! I have been using it, and it rocks.