### PR TITLE
Change Pin type to uint16

### DIFF
--- a/rpio.go
+++ b/rpio.go
@@ -81,7 +81,7 @@ import (
 )
 
 type Mode uint8
-type Pin uint8
+type Pin uint16
 type State uint8
 type Pull uint8
 type Edge uint8


### PR DESCRIPTION
Change Pin type definition to uint16 to support GPIO expansion ICs.

e.g.: Using the kernel module gpio_pca953x for the PCA9555 IC does
provide a GPIO base of 496.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>