### PR TITLE
Fix incorrect core_freq for Raspberry Pi 4, Raspberry Pi 400 and CM4

### DIFF
--- a/spi.go
+++ b/spi.go
@@ -61,8 +61,11 @@ func SpiEnd(dev SpiDev) {
 // Param speed may be as big as 125MHz in theory, but
 // only values up to 31.25MHz are considered relayable.
 func SpiSpeed(speed int) {
-	const baseFreq = 250 * 1000000
-	cdiv := uint32(baseFreq / speed)
+	coreFreq := 250 * 1000000
+	if isBCM2711() {
+		coreFreq = 550 * 1000000
+	}
+	cdiv := uint32(coreFreq / speed)
 	setSpiDiv(cdiv)
 }
 


### PR DESCRIPTION
Compare https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/config_txt/overclocking.adoc. Unfortunately i found no easy way to read 'core_freq'. This would be great, since the value is "wrong" for most of the RPi revisions.