### PR TITLE
Try gpiomem when /dev/mem is not found

### DIFF
--- a/rpio.go
+++ b/rpio.go
@@ -744,7 +744,7 @@ func Open() (err error) {
 
 	// Open fd for rw mem access; try dev/mem first (need root)
 	file, err = os.OpenFile("/dev/mem", os.O_RDWR|os.O_SYNC, os.ModePerm)
-	if os.IsPermission(err) { // try gpiomem otherwise (some extra functions like clock and pwm setting wont work)
+	if os.IsNotExist(err) || os.IsPermission(err) { // try gpiomem otherwise (some extra functions like clock and pwm setting wont work)
 		file, err = os.OpenFile("/dev/gpiomem", os.O_RDWR|os.O_SYNC, os.ModePerm)
 	}
 	if err != nil {


### PR DESCRIPTION
When running go-rpio inside a docker container with only /dev/gpiomem mounted, the library fails (`docker run --device /dev/gpiomem`). 
Currently, it only checks whether there is a permission problem with /dev/mem. In this case, however, /dev/mem is not found inside the container leading to a file not found error. In this case, it should also be tried if /dev/gpiomem is available.
