### PR TITLE
Fix spi speed

### DIFF
--- a/spi.go
+++ b/spi.go
@@ -65,7 +65,7 @@ func SpiSpeed(speed int) {
 	if isBCM2711() {
 		coreFreq = 550 * 1000000
 	}
-	cdiv := uint32((coreFreq + 2*speed) / speed)
+	cdiv := uint32((coreFreq + 2*speed - 1) / speed)
 	setSpiDiv(cdiv)
 }
 

--- a/spi.go
+++ b/spi.go
@@ -65,7 +65,7 @@ func SpiSpeed(speed int) {
 	if isBCM2711() {
 		coreFreq = 550 * 1000000
 	}
-	cdiv := uint32(coreFreq / speed)
+	cdiv := uint32((coreFreq + 2*speed) / speed)
 	setSpiDiv(cdiv)
 }
 


### PR DESCRIPTION
Round down cdiv result make real CLK faster than caller expect.

for example:
1. when call SpiSpeed(6000000) // caller want set CLK to 6MHz
```
cdiv = uint32(250000000 / 6000000) = 41
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 40, which result CLK = 6.25MHz

new implement:
cdiv = uint32((250000000 + 12000000 - 1) / 6000000) = 43
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 42, which result CLK = 5.95MHz
```
1. when call SpiSpeed(11000000) // caller want set CLK to 11MHz
```
cdiv = uint32(250000000 / 11000000) = 22
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 22, which result CLK = 11.36MHz

new implement:
cdiv = uint32((250000000 + 22000000 - 1) / 11000000) = 24
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 24, which result CLK = 10.4MHz
```
1. when call SpiSpeed(500000) // caller want set CLK to 5MHz
```
cdiv = uint32(250000000 / 5000000) = 50
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 50, which result CLK = 5MHz

new implement:
cdiv = uint32((250000000 + 10000000 - 1) / 5000000) = 51
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 50, which result CLK = 5MHz
```
1. when call SpiSpeed(1000000) // caller want set CLK to 10MHz
```
cdiv = uint32(250000000 / 10000000) = 25
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 24, which result CLK = 10.4MHz

new implement:
cdiv = uint32((250000000 + 20000000 - 1) / 10000000) = 26
with setSpiDiv will ignore LSB of cdiv, real cdiv will be 26, which result CLK = 9.6MHz
```