### PR TITLE
Use the modern unsafe replacement of reflect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/stianeikeland/go-rpio/v4
 
-go 1.15
+go 1.21

--- a/rpio.go
+++ b/rpio.go
@@ -73,7 +73,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"os"
-	"reflect"
 	"sync"
 	"syscall"
 	"time"
@@ -803,10 +802,7 @@ func memMap(fd uintptr, base int64) (mem []uint32, mem8 []byte, err error) {
 		return
 	}
 	// Convert mapped byte memory to unsafe []uint32 pointer, adjust length as needed
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&mem8))
-	header.Len /= (32 / 8) // (32 bit = 4 bytes)
-	header.Cap /= (32 / 8)
-	mem = *(*[]uint32)(unsafe.Pointer(&header))
+	mem = unsafe.Slice((*uint32)(unsafe.Pointer(unsafe.SliceData(mem8))), len(mem8)/4)
 	return
 }
 


### PR DESCRIPTION
As of Go1.20, “safer” versions of pointer casting are available to point to the
same address. Use them.
